### PR TITLE
Visual changes

### DIFF
--- a/src/liveMarkbookCalculator.js
+++ b/src/liveMarkbookCalculator.js
@@ -154,6 +154,10 @@ const makeMarkbookEditable = () => {
                 inputHTML = `<span>${value}</span><input min="0" type="number" value="" style="display: none;" />`;
             else
                 return; // Ignore other values
+
+            // fix background colour styling
+            let rowStyle = $(this).parent().find('td:first').attr('style').split(';')[0] + ';';
+            $(this).attr('style', rowStyle);
         }
 
         $(this).html(inputHTML);

--- a/src/liveMarkbookCalculator.js
+++ b/src/liveMarkbookCalculator.js
@@ -206,7 +206,26 @@ const highlightChanges = () => {
  * @desc Converts the current open markbook to an editable format
  */
 const makeMarkbookEditable = () => {
-    $('#markbookTable table').prepend('<style type="text/css">input[type="number"]::-webkit-outer-spin-button,input[type="number"]::-webkit-inner-spin-button {-webkit-appearance: none;margin: 0;} input[type="number"] {-moz-appearance: textfield; margin: 0; border: none; display: inline; font-family: Monaco, Courier, monospace; font-size: inherit; padding: 0; text-align: center; width: 30pt; background-color: inherit;}</style>');
+    $('#markbookTable table').prepend(`
+    <style type="text/css">
+        input[type="number"]::-webkit-outer-spin-button, input[type="number"]::-webkit-inner-spin-button {
+            -webkit-appearance: none;
+            margin: 0;
+        } 
+        
+        input[type="number"] {
+            -moz-appearance: textfield; 
+            margin: 0; 
+            border: none; 
+            display: inline; 
+            font-family: Monaco, Courier, monospace; 
+            font-size: inherit; 
+            padding: 0; 
+            text-align: center; 
+            width: 30pt; 
+            background-color: inherit;
+        }
+    </style>`);
     initialFinalMark = parseFloat($('#markbookTable > div > div').text().substr(11)); // Grab everything after 'Term Mark: '
     $('#markbookTable table tbody td:nth-child(n+2):nth-child(-n+5):not(:nth-child(3))').each(function () {
         let value = $(this).text();

--- a/src/liveMarkbookCalculator.js
+++ b/src/liveMarkbookCalculator.js
@@ -168,6 +168,34 @@ const createInitialMarkbook = () => {
         });
     });
 };
+
+const highlightChanges = () => {
+    $('#markbookTable table tbody > tr:gt(0)').each(function (i) {
+        const row = $(this);
+
+        const currentMark = row.find('td:nth-child(2) > input');
+        if (currentMark.val() !== initialMarkbook[i].mark.val) {
+            currentMark.parent().css('background-color', '#ffe499');
+        } else {
+            currentMark.parent().css('background-color', initialMarkbook[i].mark.bgColor);
+        }
+
+        const currentWeight = row.find('td:nth-child(4) > input');
+        if (currentWeight.val() !== initialMarkbook[i].weight.val) {
+            currentWeight.parent().css('background-color', '#ffe499');
+        } else {
+            currentWeight.parent().css('background-color', initialMarkbook[i].weight.bgColor);
+        }
+
+        const currentDenominator = row.find('td:nth-child(5) > input');
+        if (currentDenominator.val() !== initialMarkbook[i].denominator.val) {
+            currentDenominator.parent().css('background-color', '#ffe499');
+        } else {
+            currentDenominator.parent().css('background-color', initialMarkbook[i].denominator.bgColor);
+        }
+    });
+};
+
 /**
  * @desc Converts the current open markbook to an editable format
  */
@@ -210,7 +238,7 @@ const makeMarkbookEditable = () => {
         }
         $(input).bind('input', function () {
             calculateMarks();
-            $(this).parent().css('background-color', '#ffe499'); // Change color of cell to indicate it was modified
+            highlightChanges();
         });
     });
 };

--- a/src/liveMarkbookCalculator.js
+++ b/src/liveMarkbookCalculator.js
@@ -175,7 +175,12 @@ const makeMarkbookEditable = () => {
     $('#markbookTable table').prepend('<style type="text/css">input[type="number"]::-webkit-outer-spin-button,input[type="number"]::-webkit-inner-spin-button {-webkit-appearance: none;margin: 0;} input[type="number"] {-moz-appearance: textfield; margin: 0; border: none; display: inline; font-family: Monaco, Courier, monospace; font-size: inherit; padding: 0; text-align: center; width: 30pt; background-color: inherit;}</style>');
     initialFinalMark = parseFloat($('#markbookTable > div > div').text().substr(11)); // Grab everything after 'Term Mark: '
     $('#markbookTable table tbody td:nth-child(n+2):nth-child(-n+5):not(:nth-child(3))').each(function () {
-        const value = $(this).text();
+        let value = $(this).text();
+
+        if (!isNaN(parseFloat(value)) && value !== '') {
+            value = +parseFloat(value).toFixed(2);
+        }
+
         let inputHTML = `<input min="0" type="number" value="${value}" />`;
 
         if (isNaN(parseFloat(value)) && value !== '') {

--- a/src/liveMarkbookCalculator.js
+++ b/src/liveMarkbookCalculator.js
@@ -68,6 +68,12 @@ const calculateMarks = () => {
     let finalMark = +(calculateLayer(markbook) * 100).toFixed(3);
     let finalMarkSelector = $('#markbookTable > div > div');
 
+    // if there is no mark change, don't display the final mark
+    if (initialFinalMark == finalMark) {
+        finalMarkSelector.text(`Term Mark: ${initialFinalMark}`);
+        return;
+    }
+
     // Display the final grade with the initial grade faded
     finalMarkSelector.text('Term Mark: ');
     finalMarkSelector.append(`<span style="opacity: 0.7;">${initialFinalMark} →</span> ${finalMark}`)

--- a/src/liveMarkbookCalculator.js
+++ b/src/liveMarkbookCalculator.js
@@ -260,6 +260,7 @@ loadMarkbook = function (studentID, classID, termID, topicID, title, refresh, st
             $('#MarkbookDialog').dialog('option', 'height', 'auto').dialog('open');
             $('#markbookTable td[mrkTble!=\'1\']').addClass('tdAchievement');
             makeMarkbookEditable();
+            createInitialMarkbook();
         },
         error: function () {
             $('#markbookTable').html('(error loading marbook)');

--- a/src/liveMarkbookCalculator.js
+++ b/src/liveMarkbookCalculator.js
@@ -192,8 +192,8 @@ const makeMarkbookEditable = () => {
                 return; // Ignore other values
 
             // fix background colour styling
-            let rowStyle = $(this).parent().find('td:first').attr('style').split(';')[0] + ';';
-            $(this).attr('style', rowStyle);
+            let rowStyle = $(this).parent().find('td:first').css('background-color');
+            $(this).css('background-color', rowStyle);
         }
 
         $(this).html(inputHTML);

--- a/src/liveMarkbookCalculator.js
+++ b/src/liveMarkbookCalculator.js
@@ -273,7 +273,6 @@ const makeMarkbookEditable = () => {
             $(input).bind('input', function () {
                 calculateMarks();
                 highlightChanges();
-                calculatePercentages();
             });
         }
     });

--- a/src/liveMarkbookCalculator.js
+++ b/src/liveMarkbookCalculator.js
@@ -167,6 +167,7 @@ const makeMarkbookEditable = () => {
         if (span) {
             $(span).bind('click', function () {
                 input.show();
+                input.focus();
                 calculateMarks();
                 $(this).remove();
             });

--- a/src/liveMarkbookCalculator.js
+++ b/src/liveMarkbookCalculator.js
@@ -144,6 +144,9 @@ const parseMarkbook = () => {
     return markbook;
 };
 
+/**
+ * @desc Iterates over the current markbook and stores the mark, weight, and denominator value, as well as background colour, in an array
+ */
 const createInitialMarkbook = () => {
     initialMarkbook = [];
 
@@ -169,6 +172,9 @@ const createInitialMarkbook = () => {
     });
 };
 
+/**
+ * @desc Iterates over the current markbook and highlights changed cells
+ */
 const highlightChanges = () => {
     $('#markbookTable table tbody > tr:gt(0)').each(function (i) {
         const row = $(this);

--- a/src/liveMarkbookCalculator.js
+++ b/src/liveMarkbookCalculator.js
@@ -264,9 +264,18 @@ const makeMarkbookEditable = () => {
         
         const margin = $(this).parent().find('td:first > span:first')[0].style['margin-left']; // determines if the row is for an assignment, section, or unit
         const isMarkColumn = $(this).nextAll().length === 3; // the mark column has 3 cells after it
+        
+        let hasChildren;
+        if ($(this).parent().nextAll().length !== 0) { // check if the current row is the last row
+            const nextMargin = $(this).parent().next().find('td:first > span:first')[0].style['margin-left'];
+            hasChildren = margin !== nextMargin;
+        } else {
+            hasChildren = false;
+        }
 
-        // only make assignment marks editable; section and unit marks are dependent on assignments, so their input fields are disabled
-        if (margin !== '40px' && isMarkColumn) {
+        // only assignments and sections/units without children should have their marks editable 
+        // other marks are dependent on the marks of their children so their input fields should be disabled
+        if (margin !== '40px' && isMarkColumn && hasChildren) {
             $(input).prop('disabled', true); // to maintain compatibility with other functions, the input is disabled rather than completely removed
             $(input).css('cursor', 'text'); // give the appearance of regular text
         } else {

--- a/src/liveMarkbookCalculator.js
+++ b/src/liveMarkbookCalculator.js
@@ -245,7 +245,7 @@ const makeMarkbookEditable = () => {
                 return; // Ignore other values
 
             // fix background colour styling
-            let rowStyle = $(this).parent().find('td:first').css('background-color');
+            const rowStyle = $(this).parent().find('td:first').css('background-color');
             $(this).css('background-color', rowStyle);
         }
 

--- a/src/liveMarkbookCalculator.js
+++ b/src/liveMarkbookCalculator.js
@@ -1,4 +1,5 @@
 let initialFinalMark; // Stores the initial final grade
+let initialMarkbook; // Stores the initial markbook
 
 /**
  * @desc Takes in a mark layer and calculates the total mark based off weights and raw score
@@ -143,6 +144,30 @@ const parseMarkbook = () => {
     return markbook;
 };
 
+const createInitialMarkbook = () => {
+    initialMarkbook = [];
+
+    $('#markbookTable table tbody > tr:gt(0)').each(function () {
+        const mark = $(this).find('td:nth-child(2) > input');
+        const weight = $(this).find('td:nth-child(4) > input');
+        const denominator = $(this).find('td:nth-child(5) > input');
+
+        initialMarkbook.push({
+            mark: {
+                val: mark.val(),
+                bgColor: mark.parent().css('background-color')
+            },
+            weight: {
+                val: weight.val(),
+                bgColor: weight.parent().css('background-color')
+            },
+            denominator: {
+                val: denominator.val(),
+                bgColor: denominator.parent().css('background-color')
+            }
+        });
+    });
+};
 /**
  * @desc Converts the current open markbook to an editable format
  */

--- a/src/liveMarkbookCalculator.js
+++ b/src/liveMarkbookCalculator.js
@@ -261,10 +261,21 @@ const makeMarkbookEditable = () => {
                 $(this).remove();
             });
         }
-        $(input).bind('input', function () {
-            calculateMarks();
-            highlightChanges();
-        });
+        
+        const margin = $(this).parent().find('td:first > span:first')[0].style['margin-left']; // determines if the row is for an assignment, section, or unit
+        const isMarkColumn = $(this).nextAll().length === 3; // the mark column has 3 cells after it
+
+        // only make assignment marks editable; section and unit marks are dependent on assignments, so their input fields are disabled
+        if (margin !== '40px' && isMarkColumn) {
+            $(input).prop('disabled', true); // to maintain compatibility with other functions, the input is disabled rather than completely removed
+            $(input).css('cursor', 'text'); // give the appearance of regular text
+        } else {
+            $(input).bind('input', function () {
+                calculateMarks();
+                highlightChanges();
+                calculatePercentages();
+            });
+        }
     });
 };
 


### PR DESCRIPTION
## Major Changes
### 1. Highlight all modified cells
Before, a cell was permanently highlighted after its input value was changed and did not revert to the initial colour when the value was changed back. Now, the initial markbook values are stored and every time an input value is changed, all cells are checked to see if their new value matches their initial value. If the values do not match, the cell is highlighted.

This also means that section and unit rows will now have mark values highlighted. Before, the program would only highlight cells that are directly changed, but that is now fixed.

### 2. Only assignment marks are editable
Before, the UI was misleading, as it allowed the user to click into the input of section and unit marks. However, the algorithm for calculating marks works in a way such that any changes to these inputs is not reflected in the final mark. This is now amended, as the user no longer has the option to click into the inputs for the mark of sections and units.


## Minor Changes
### 1. Autofocus on input when editing text marks
Before, the user had to click twice in order to edit the value of a NHI, INC, EXC, ABS, or COL. This now only requires a single click.

### 2. Only display the new final mark if it is different
Before, upon changing a mark, the new final mark was shown alongside the initial mark even if they were equivalent. Now, the final mark is only shown when there is a difference between it and the initial final mark that is non-zero.

### 3. Fixed background colour styling of text marks
Before, any cell containing an NHI, INC, EXC, ABS, or COL had  a white background colour. The cell background colour is now consistent with the other cells in the row.

### 4. All initial number values are rounded to two decimal places
This enables the comparison between the new mark and initial mark, as when calculating new marks, all number values are rounded to two decimal places.